### PR TITLE
Https migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,22 @@
         <uk.ac.ebi.pride.architectural-pride-logging.version>1.0.0</uk.ac.ebi.pride.architectural-pride-logging.version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.7.2</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Tests.java</include>
+                    </includes>
+                    <junitArtifactName>junit:junit</junitArtifactName>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>uk.ac.ebi.pride.architectural</groupId>

--- a/src/main/java/uk/ac/ebi/pride/pubmed/PubMedFetcher.java
+++ b/src/main/java/uk/ac/ebi/pride/pubmed/PubMedFetcher.java
@@ -28,7 +28,7 @@ public class PubMedFetcher {
    */
   public static EupmcReferenceSummary getPubMedSummary(String pubmedId) throws URISyntaxException, IOException {
     EupmcReferenceSummary result;
-    final String REQUEST_URL = "http://www.ebi.ac.uk/europepmc/webservices/rest/search?query=ext_id:" + pubmedId + "%20src:med&format=json";
+    final String REQUEST_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=ext_id:" + pubmedId + "%20src:med&format=json";
     log.info("Requesting EUPMC WS using: " + REQUEST_URL);
     EupmcResponse response = performEupmcQuery(REQUEST_URL);
     if (response!=null) {


### PR DESCRIPTION
Now uses Maven's surefire plugin for unit test support.
Accesses th EU PMC REST WS using HTTPS, as regular HTTP has now been disabled (without warning!).