### PR TITLE
firstIndexDate field added to model

### DIFF
--- a/src/main/java/uk/ac/ebi/pride/pubmed/model/EupmcResult.java
+++ b/src/main/java/uk/ac/ebi/pride/pubmed/model/EupmcResult.java
@@ -32,6 +32,7 @@ public class EupmcResult {
   String hasLabsLinks;
   String hasTMAccessionNumbers;
   EupmcTmAccessionTypeArray tmAccessionTypeList;
+  String firstIndexDate;
   String firstPublicationDate;
 
   /**
@@ -554,5 +555,23 @@ public class EupmcResult {
    */
   public void setTmAccessionTypeList(EupmcTmAccessionTypeArray tmAccessionTypeList) {
     this.tmAccessionTypeList = tmAccessionTypeList;
+  }
+
+  /**
+   * Gets firstIndexDate.
+   *
+   * @return Value of firstIndexDate.
+   */
+  public String getFirstIndexDate() {
+    return firstIndexDate;
+  }
+
+  /**
+   * Sets new firstIndexDate.
+   *
+   * @param firstIndexDate New value of firstIndexDate.
+   */
+  public void setFirstIndexDate(String firstIndexDate) {
+    this.firstIndexDate = firstIndexDate;
   }
 }


### PR DESCRIPTION
It seems Europe PMC has added a new field called `firstIndexDate` to their response, so our library fails when it tried to convert it's results to JSON as our model does not have that field. 

https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=ext_id:31019994%20src:med&format=json

`{"version":"6.1","hitCount":1,"nextCursorMark":"AoIIQNw57SgzOTgxOTk0MQ==","request":{"query":"ext_id:31019994 src:med","resultType":"lite","synonym":false,"cursorMark":"*","pageSize":25,"sort":""},"resultList":{"result":[{"id":"31019994","source":"MED","pmid":"31019994","pmcid":"PMC6469343","doi":"10.1002/acn3.745","title":"Novel CSF biomarkers in genetic frontotemporal dementia identified by proteomics.","authorString":"van der Ende EL, Meeter LH, Stingl C, van Rooij JGJ, Stoop MP, Nijholt DAT, Sanchez-Valle R, Graff C, Öijerstedt L, Grossman M, McMillan C, Pijnenburg YAL, Laforce R, Binetti G, Benussi L, Ghidoni R, Luider TM, Seelaar H, van Swieten JC.","journalTitle":"Ann Clin Transl Neurol","issue":"4","journalVolume":"6","pubYear":"2019","journalIssn":"2328-9503","pageInfo":"698-707","pubType":"research-article; journal article","isOpenAccess":"Y","inEPMC":"Y","inPMC":"N","hasPDF":"Y","hasBook":"N","hasSuppl":"Y","citedByCount":0,"hasReferences":"N","hasTextMinedTerms":"Y","hasDbCrossReferences":"N","hasLabsLinks":"Y","hasTMAccessionNumbers":"N","firstIndexDate":"2019-04-26","firstPublicationDate":"2019-03-07"}]}}`